### PR TITLE
Bug - Search tweets - URL Builder

### DIFF
--- a/src/services/searchtweets.go
+++ b/src/services/searchtweets.go
@@ -13,7 +13,7 @@ func SearchTweets(query string, nextToken string) ([]*models.SearchResponse, err
 		return nil, errors.New("Invalid Request. Bearer Token is not set")
 	}
 
-	url := "https://api.twitter.com/2/tweets/search/recent?query=bet365&max_results=100"
+	url := "https://api.twitter.com/2/tweets/search/recent?query=" + query + "&max_results=100"
 
 	if nextToken != "" {
 		url = url + "&next_token=" + nextToken


### PR DESCRIPTION
## Changes Made
Updated `searchtweets` services to use the query string passed when building the URL for the twitter API